### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,9 +1,9 @@
 [![Build Status](https://travis-ci.org/ckan/ckanext-deadoralive.png)](https://travis-ci.org/ckan/ckanext-deadoralive) [![Coverage Status](https://img.shields.io/coveralls/ckan/ckanext-deadoralive.svg)](https://coveralls.io/r/ckan/ckanext-deadoralive?branch=master)
-[![Latest Version](https://pypip.in/version/ckanext-deadoralive/badge.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
-[![Downloads](https://pypip.in/download/ckanext-deadoralive/badge.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
-[![Supported Python versions](https://pypip.in/py_versions/ckanext-deadoralive/badge.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
-[![Development Status](https://pypip.in/status/ckanext-deadoralive/badge.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
-[![License](https://pypip.in/license/ckanext-deadoralive/badge.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
+[![Latest Version](https://img.shields.io/pypi/v/ckanext-deadoralive.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
+[![Downloads](https://img.shields.io/pypi/dm/ckanext-deadoralive.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/ckanext-deadoralive.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
+[![Development Status](https://img.shields.io/pypi/status/ckanext-deadoralive.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
+[![License](https://img.shields.io/pypi/l/ckanext-deadoralive.svg)](https://pypi.python.org/pypi/ckanext-deadoralive/)
 
 
 ckanext-deadoralive


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ckanext-deadoralive))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ckanext-deadoralive`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.