### PR TITLE
Ckan28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,46 @@
-.ropeproject/*
-ckanext_deadoralive.egg-info/*
-*.pyc
-
-dist/*
-build/*
+.ropeproject
 node_modules
 bower_components
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+sdist/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Sphinx documentation
+docs/_build/
+
+# PyCharm
+.idea
+venv

--- a/ckanext/deadoralive/logic/action/get.py
+++ b/ckanext/deadoralive/logic/action/get.py
@@ -136,9 +136,9 @@ def _broken_links_by_organization(context, organization_list, all_results,
             "name": organization["name"],
             "display_name": (organization.get("title")
                              or organization.get("name")),
-            "image_display_url": organization["image_display_url"],
-            "description": organization["description"],
-            "packages": organization["packages"],
+            "image_display_url": organization.get("image_display_url", None),
+            "description": organization.get("description", None),
+            "packages": organization.get("packages", None),
             "datasets_with_broken_links": []}
         num_broken_links = 0
 


### PR DESCRIPTION
When using with CKAN 2.8, we got an error on missing packages from organization on https://github.com/ckan/ckanext-deadoralive/blob/master/ckanext/deadoralive/logic/action/get.py#L141
```
"packages": organization["packages"],
KeyError: 'packages'

```
Changes: 

- ignore 'packages' when missing and do the same for 'description' and 'image_display_url'
- updated .gitignore